### PR TITLE
Fixed BWA verbosity.

### DIFF
--- a/bwamem_pair.c
+++ b/bwamem_pair.c
@@ -68,11 +68,12 @@ void mem_pestat(const mem_opt_t *opt, int64_t l_pac, int n, const mem_alnreg_v *
 		uint64_v *q = &isize[d];
 		int p25, p50, p75, x;
 		if (q->n < MIN_DIR_CNT) {
-			fprintf(stderr, "[M::%s] skip orientation %c%c as there are not enough pairs\n", __func__, "FR"[d>>1&1], "FR"[d&1]);
+			if (bwa_verbose >=3)
+				fprintf(stderr, "[M::%s] skip orientation %c%c as there are not enough pairs\n", __func__, "FR"[d>>1&1], "FR"[d&1]);
 			r->failed = 1;
 			free(q->a);
 			continue;
-		} else fprintf(stderr, "[M::%s] analyzing insert size distribution for orientation %c%c...\n", __func__, "FR"[d>>1&1], "FR"[d&1]);
+		} else if (bwa_verbose >=3) fprintf(stderr, "[M::%s] analyzing insert size distribution for orientation %c%c...\n", __func__, "FR"[d>>1&1], "FR"[d&1]);
 		ks_introsort_64(q->n, q->a);
 		p25 = q->a[(int)(.25 * q->n + .499)];
 		p50 = q->a[(int)(.50 * q->n + .499)];
@@ -80,8 +81,10 @@ void mem_pestat(const mem_opt_t *opt, int64_t l_pac, int n, const mem_alnreg_v *
 		r->low  = (int)(p25 - OUTLIER_BOUND * (p75 - p25) + .499);
 		if (r->low < 1) r->low = 1;
 		r->high = (int)(p75 + OUTLIER_BOUND * (p75 - p25) + .499);
-		fprintf(stderr, "[M::%s] (25, 50, 75) percentile: (%d, %d, %d)\n", __func__, p25, p50, p75);
-		fprintf(stderr, "[M::%s] low and high boundaries for computing mean and std.dev: (%d, %d)\n", __func__, r->low, r->high);
+		if (bwa_verbose >=3){
+			fprintf(stderr, "[M::%s] (25, 50, 75) percentile: (%d, %d, %d)\n", __func__, p25, p50, p75);
+			fprintf(stderr, "[M::%s] low and high boundaries for computing mean and std.dev: (%d, %d)\n", __func__, r->low, r->high);
+	  }
 		for (i = x = 0, r->avg = 0; i < q->n; ++i)
 			if (q->a[i] >= r->low && q->a[i] <= r->high)
 				r->avg += q->a[i], ++x;
@@ -90,13 +93,15 @@ void mem_pestat(const mem_opt_t *opt, int64_t l_pac, int n, const mem_alnreg_v *
 			if (q->a[i] >= r->low && q->a[i] <= r->high)
 				r->std += (q->a[i] - r->avg) * (q->a[i] - r->avg);
 		r->std = sqrt(r->std / x);
-		fprintf(stderr, "[M::%s] mean and std.dev: (%.2f, %.2f)\n", __func__, r->avg, r->std);
+		if (bwa_verbose >=3)
+			fprintf(stderr, "[M::%s] mean and std.dev: (%.2f, %.2f)\n", __func__, r->avg, r->std);
 		r->low  = (int)(p25 - MAPPING_BOUND * (p75 - p25) + .499);
 		r->high = (int)(p75 + MAPPING_BOUND * (p75 - p25) + .499);
 		if (r->low  > r->avg - MAX_STDDEV * r->std) r->low  = (int)(r->avg - MAX_STDDEV * r->std + .499);
 		if (r->high < r->avg + MAX_STDDEV * r->std) r->high = (int)(r->avg + MAX_STDDEV * r->std + .499);
 		if (r->low < 1) r->low = 1;
-		fprintf(stderr, "[M::%s] low and high boundaries for proper pairs: (%d, %d)\n", __func__, r->low, r->high);
+		if (bwa_verbose >=3)
+			fprintf(stderr, "[M::%s] low and high boundaries for proper pairs: (%d, %d)\n", __func__, r->low, r->high);
 		free(q->a);
 	}
 	for (d = 0, max = 0; d < 4; ++d)
@@ -104,7 +109,8 @@ void mem_pestat(const mem_opt_t *opt, int64_t l_pac, int n, const mem_alnreg_v *
 	for (d = 0; d < 4; ++d)
 		if (pes[d].failed == 0 && isize[d].n < max * MIN_DIR_RATIO) {
 			pes[d].failed = 1;
-			fprintf(stderr, "[M::%s] skip orientation %c%c\n", __func__, "FR"[d>>1&1], "FR"[d&1]);
+			if (bwa_verbose >=3)
+				fprintf(stderr, "[M::%s] skip orientation %c%c\n", __func__, "FR"[d>>1&1], "FR"[d&1]);
 		}
 }
 
@@ -153,8 +159,8 @@ int mem_matesw(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac, co
 			if (aln.score >= opt->min_seed_len && aln.qb >= 0) { // something goes wrong if aln.qb < 0
 				b.rid = a->rid;
 				b.is_alt = a->is_alt;
-				b.qb = is_rev? l_ms - (aln.qe + 1) : aln.qb;                                                                                                                                                                              
-				b.qe = is_rev? l_ms - aln.qb : aln.qe + 1; 
+				b.qb = is_rev? l_ms - (aln.qe + 1) : aln.qb;
+				b.qe = is_rev? l_ms - aln.qb : aln.qe + 1;
 				b.rb = is_rev? (l_pac<<1) - (rb + aln.te + 1) : rb + aln.tb;
 				b.re = is_rev? (l_pac<<1) - (rb + aln.tb) : rb + aln.te + 1;
 				b.score = aln.score;


### PR DESCRIPTION
There were few places in the code where verbosity checks were not added because of which lots of unwanted logs was showing up.
https://www.pivotaltracker.com/n/projects/2205090/stories/163020376
Example logs which won't show up if we use `-v` with an INT value less than 3:
```
Jan 03 16:25:30 task 2184.77983: [AlignFastq_f286204bef] [M::mem_pestat] low and high boundaries for computing mean and std.dev: (1, 207)
Jan 03 16:25:30 task 2184.77983: [AlignFastq_f286204bef] [M::mem_pestat] mean and std.dev: (20.19, 20.82)
Jan 03 16:25:30 task 2184.77983: [AlignFastq_f286204bef] [M::mem_pestat] low and high boundaries for proper pairs: (1, 273)
Jan 03 16:25:30 task 2184.77983: [AlignFastq_f286204bef] [M::mem_pestat] analyzing insert size distribution for orientation RR...
Jan 03 16:25:30 task 2184.77983: [AlignFastq_f286204bef] [M::mem_pestat] (25, 50, 75) percentile: (1035, 2018, 2688)
Jan 03 16:25:30 task 2184.77983: [AlignFastq_f286204bef] [M::mem_pestat] low and high boundaries for computing mean and std.dev: (1, 5994)
Jan 03 16:25:30 task 2184.77983: [AlignFastq_f286204bef] [M::mem_pestat] mean and std.dev: (1724.82, 1259.51)
Jan 03 16:25:30 task 2184.77983: [AlignFastq_f286204bef] [M::mem_pestat] low and high boundaries for proper pairs: (1, 7647)
Jan 03 16:25:30 task 2184.77983: [AlignFastq_f286204bef] [M::mem_pestat] skip orientation FF
```

Note: Raised a PR against `upstream-master` so that it is easy to view the differences.